### PR TITLE
Update chapter7

### DIFF
--- a/chapter7.py
+++ b/chapter7.py
@@ -70,7 +70,10 @@ while True:
 
     imgStack = stackImages(0.6,([img,imgHSV],[mask,imgResult]))
     cv2.imshow("Stacked Images", imgStack)
-
+    
     cv2.waitKey(1)
+    #if running on MacOs cv2.waitKey(1) can be completely unresponsive, replace with:
+    #cv2.waitKey(1000)
+    
 
 


### PR DESCRIPTION
 If running on MacOs cv2.waitKey(1) is completely unresponsive for trackbars,  instead setting the value to 1000 (or 500) lets it work after a brief pause. Added this in as a comment should you wish to include it.

Thank you so much for your tutorial.